### PR TITLE
Improve Helm chart

### DIFF
--- a/deployments/primate/Chart.yaml
+++ b/deployments/primate/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/primate/templates/deployment.yaml
+++ b/deployments/primate/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:latest
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "--config"

--- a/deployments/primate/templates/secret.yaml
+++ b/deployments/primate/templates/secret.yaml
@@ -76,3 +76,4 @@ stringData:
     cookie_httponly = true
     # cookie_domains = ""
 
+    {{ .Values.proxy.customConfig | nindent 4 }}

--- a/deployments/primate/values.yaml
+++ b/deployments/primate/values.yaml
@@ -79,6 +79,9 @@ tolerations: []
 affinity: {}
 
 proxy:
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: latest
   # required
   cookieSecret: ""
   # required
@@ -103,6 +106,7 @@ proxy:
     # entries:
     #  - testuser:{SHA}EWhzdhgoYJWy0z2gyzhRYlN9DSiv
     entries: {}
+  customConfig: |
 
 # copied from configs/config_example.yaml
 primateConfig: |


### PR DESCRIPTION
- make oauth2-proxy image configurable
- add possibility to customize proxy config

This improvements are needed because oauth2-proxy 7.3.0 isn't correctly working with GitHub (see https://togithub.com/oauth2-proxy/oauth2-proxy/issues/1724)